### PR TITLE
Move to from Colorizable to Terminal::ANSIColor

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -12,7 +12,7 @@
     "YAMLish",
     "JSON::Tiny",
     "Data::Dump",
-    "Colorizable"
+    "Terminal::ANSIColor"
   ],
   "description": "Sparrow is a Raku based automation framework",
   "license": "Artistic-2.0",

--- a/color-test.raku
+++ b/color-test.raku
@@ -1,12 +1,12 @@
-use Colorizable;
+use Terminal::ANSIColor;
 
-my $planet = "Sparrow" but Colorizable;
+my $planet = "Sparrow";
 
-say $planet.colorize(:fg(blue), :bg(red), :mo(bold));
-say $planet.colorize(:fg(blue), :bg(green), :mo(italic));
-say $planet.colorize(:fg(green));
-say $planet.colorize(:fg(green), :mo(bold));
-say $planet.colorize(:fg(green), :mo(italic));
-say $planet.colorize(:fg(red), :mo(italic));
-say $planet.colorize(:fg(cyan), :mo(italic));
-say $planet.colorize(:fg(yellow), :mo(italic));
+say $planet.&colored('bold blue on_red');
+say $planet.&colored('italic blue on_green');
+say $planet.&colored('green');
+say $planet.&colored('bold green');
+say $planet.&colored('italic green');
+say $planet.&colored('italic red');
+say $planet.&colored('italic cyan');
+say $planet.&colored('italic yellow');

--- a/lib/Sparrow6/Common/Helpers.pm6
+++ b/lib/Sparrow6/Common/Helpers.pm6
@@ -3,7 +3,7 @@
 unit module Sparrow6::Common::Helpers;
 
 my $timeformat = sub ($self) { sprintf "%02d:%02d:%02d %02d/%02d/%04d", .hour, .minute, .second,   .month, .day, .year given $self; };
-use Colorizable;
+use Terminal::ANSIColor;
 
 role Role {
 
@@ -17,18 +17,18 @@ role Role {
 
   method console ($message) {
 
-    my $header = "[{$.name}]" but Colorizable;
-    my $ts = "{DateTime.new(now, formatter => $timeformat)}" but Colorizable;
+    my $header = "[{$.name}]";
+    my $ts = DateTime.now(formatter => $timeformat).Str;
     if %*ENV<SP6_FORMAT_TERSE> {
       say $message
     } elsif %*ENV<SP6_LOG_NO_TIMESTAMPS> {
-      say %*ENV<SP6_FORMAT_COLOR> 
-        ?? "{$header.colorize(:fg(magenta))} :: {$message}" 
-        !! "$header :: {$message}";
+      say %*ENV<SP6_FORMAT_COLOR>
+        ?? "$header.&colored('magenta') :: $message"
+        !! "$header :: $message";
     } else {
-      say %*ENV<SP6_FORMAT_COLOR> 
-        ?? "{$ts.colorize(:fg(magenta))} {$header.colorize(:fg(magenta))} :: {$message}" 
-        !! "$ts $header :: {$message}";
+      say %*ENV<SP6_FORMAT_COLOR>
+        ?? "$ts.&colored('magenta') $header.&colored('magenta') :: $message"
+        !! "$ts $header :: $message";
     }
 
   };

--- a/lib/Sparrow6/Task/Runner/Helpers/Common.pm6
+++ b/lib/Sparrow6/Task/Runner/Helpers/Common.pm6
@@ -3,7 +3,7 @@
 unit module Sparrow6::Task::Runner::Helpers::Common;
 
 use JSON::Tiny;
-use Colorizable;
+use Terminal::ANSIColor;
 
 role Role {
 
@@ -15,35 +15,29 @@ role Role {
 
   method !check-log (%data) {
 
-    my $message = %data<message> but Colorizable;
+    my $message = %data<message>;
     my $status = %data<status>;
+    my $header = "[task check]";
 
     if %data<type> eq "check" and %data<status>:exists {
-      my $status-str = "{%data<status>}" but Colorizable;
-      my $header = "[task check]" but Colorizable;
+      my $status-str = %data<status>;
       if %*ENV<SP6_FORMAT_COLOR> {
         if $status eq True {
-          say $header.colorize(:fg(cyan)), " ", $message, " ", $status-str.colorize(:fg(cyan))
+          say $header.&colored('cyan'), " ", $message, " ", $status-str.&colored('cyan')
         } elsif $status eq False {
-          say $header.colorize(:fg(red)), " ", $message, " ", $status-str.colorize(:fg(red))
+          say $header.&colored('red'), " ", $message, " ", $status-str.&colored('red')
         }
       } else {
           say $header, " ", $message, " ", $status;
       }
     } elsif %data<type> eq "note" {
-      my $header = "[task check]" but Colorizable;
       if %*ENV<SP6_FORMAT_COLOR> {
-        say $header.colorize(:fg(yellow)), " ", $message.colorize(:fg(yellow));
+        say $header.&colored('yellow'), " ", $message.&colored('yellow');
       } else {
         say $header, " ", $message;
       }
     } else {
-      my $header = "[task check]" but Colorizable;
-      if %*ENV<SP6_FORMAT_COLOR> {
-        say $header, " ", $message;
-      } else {
-        say $header, " ", $message;
-      }
+      say $header, " ", $message;
     }
   };
 


### PR DESCRIPTION
Colorizable seems to be abandoned, and Terminal::ANSIColor is already
an indirect dependency for Sparky (cro uses it), so with this change
we are actually decreasing our footprint.